### PR TITLE
Fix module name of core project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,10 +19,11 @@ lazy val root = Project(id = "scalacache",base = file("."))
 lazy val core = CrossProject(id = "scalacache-core", file("core"), CrossType.Full)
   .settings(commonSettings: _*)
   .settings(
-    libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value
-  )
-  .settings(
-    libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.13.4" % Test,
+    moduleName := "scalacache-core",
+    libraryDependencies ++= Seq(
+      "org.scala-lang" % "scala-reflect" % scalaVersion.value,
+      "org.scalacheck" %% "scalacheck" % "1.13.4" % Test
+    ),
     scala211OnlyDeps(
       "org.squeryl" %% "squeryl" % "0.9.5-7" % Test,
       "com.h2database" % "h2" % "1.4.182" % Test


### PR DESCRIPTION
This is so the published artifact keeps its existing name of "scalacache-core", rather than changing to "scalacache-corejvm".

Once you've merged this in, I'm happy to merge your PR into the main repo.